### PR TITLE
reroute after login

### DIFF
--- a/client/components/DocsListByUserId.js
+++ b/client/components/DocsListByUserId.js
@@ -20,7 +20,6 @@ class DocsListByUserId extends Component {
 
   componentDidMount() {
     const { userId } = this.props;
-    console.log('userId: ', userId);
     this.unsubscribe = db.collection('users').doc(userId)
       .onSnapshot((doc) => {
         this.onSnapshotCallback(doc).catch(err => console.error(err));
@@ -32,9 +31,9 @@ class DocsListByUserId extends Component {
   }
 
   async onSnapshotCallback(doc) {
-    if (doc.data().documents.length) {
+    if (doc.data().documents) {
       const docIds = Object.keys(doc.data().documents);
-      const docsInfo = (await Promise.all(docIds.map(docId => db.collection('documents').doc(docId).get()))).map(curDoc => curDoc.data());
+      const docsInfo = (await Promise.all(docIds.map(docId => db.collection('notebooks').doc(docId).get()))).map(curDoc => curDoc.data());
       this.setState({ docsInfo });
     }
   }

--- a/client/components/GroupsListByUserId.js
+++ b/client/components/GroupsListByUserId.js
@@ -22,7 +22,6 @@ class GroupsListByUserId extends Component {
     const { userId } = this.props;
     this.unsubscribe = db.collection('users').doc(userId)
       .onSnapshot((doc) => {
-        console.log('doc::::: ', doc.data());
         this.onSnapshotCallback(doc).catch(err => console.error(err));
       });
   }
@@ -32,8 +31,7 @@ class GroupsListByUserId extends Component {
   }
 
   async onSnapshotCallback(doc) {
-    console.log("length???", doc.data().groups.hasOwnProperty());
-    if (doc.data().groups.length) {
+    if (doc.data().groups) {
       const groupIds = Object.keys(doc.data().groups);
       const groupsInfo = (await Promise.all(groupIds.map(groupId => db.collection('groups').doc(groupId).get()))).map(curGroup => curGroup.data());
       this.setState({ groupsInfo });

--- a/client/components/SingleUser.js
+++ b/client/components/SingleUser.js
@@ -2,6 +2,8 @@ import React, {Component} from 'react';
 import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
 import {Tabs, Tab} from 'material-ui/Tabs';
 import FlatButton from 'material-ui/FlatButton';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+import ContentAdd from 'material-ui/svg-icons/content/add';
 import { DocsListByUserId, GroupsListByUserId } from './';
 import { fetchUserFunction } from '../crud/user';
 import { db } from '../../firebase/initFirebase';
@@ -12,9 +14,8 @@ class SingleUser extends Component {
     this.state = {
       userInfo: {},
       userId: this.props.match.params.userId,
-      value: 'a',
+      value: '',
     };
-    // this.fetchUser = this.fetchUser.bind(this);
   }
 
   componentDidMount() {
@@ -22,8 +23,6 @@ class SingleUser extends Component {
     this.unsubscribe = db.collection('users').doc(userId)
       .onSnapshot((doc) => {
         this.setState({userInfo: doc.data()})
-        // this.onSnapshotCallback(doc).catch(err =>
-        // console.error(err));
       });
   }
 
@@ -32,39 +31,9 @@ class SingleUser extends Component {
   }
 
   async onSnapshotCallback(doc) {
-    // const docIds = Object.keys(doc.data().documents);
-    // const docsInfo = (await Promise.all(docIds.map(docId => db.collection('documents').doc(docId).get()))).map(curDoc => curDoc.data());
-    // this.setState({ docsInfo });
-
-
-    // console.log("doc", doc);
-
-
-
-
     const userInfo = doc.data();
-    // const userInfo = (await Promise.all())
-
     this.setState({ userInfo });
   }
-
-
-  // fetchUser() {
-  //   const { userId } = this.props.match.params;
-  //   const user = fetchUserFunction(userId);
-  //   console.log('user: ', user);
-  //   this.setState({
-  //     user,
-  //     userId,
-  //   })
-  // }
-
-
-
-
-
-
-
 
   handleChange = (value) => {
     this.setState({
@@ -72,25 +41,11 @@ class SingleUser extends Component {
     })
   }
 
-
-
-
   render() {
-    // const { userId } = this.props.match.params;
-
-    setTimeout(() => {
-      console.log("state", this.state)
-
-    }, 2500)
-
     const { userId } = this.state;
-
-    // const userId = this.state.userInfo.id;
-
-
+    const { userInfo } = this.state;
     return(
       <div>
-
         <div className="userPage">
           <div className="userPic">
             <CardMedia
@@ -100,9 +55,10 @@ class SingleUser extends Component {
               <img
               src="https://i0.wp.com/www.thisblogrules.com/wp-content/uploads/2010/02/batman-for-facebook.jpg?resize=250%2C280" alt="" />
             </CardMedia>
-          </div>
-          <div className="userInfo">
-            <CardTitle title={"Name: "}  subtitle="Card subtitle" />
+
+            <CardTitle
+            title={ `Name: ${userInfo.displayName}` }
+            subtitle="Card subtitle" />
             <CardText>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               Donec mattis pretium massa. Aliquam erat volutpat. Nulla facilisi.
@@ -114,31 +70,29 @@ class SingleUser extends Component {
               <FlatButton label="Action2" />
             </CardActions>
           </div>
-        </div>
-
-        <div>
+          <div className="userInfo">
           <Tabs
             value={this.state.value}
             onChange={this.handleChange}
           >
             <Tab label="Groups" value="a">
               <div>
-                {/* <h2>Controllable Tab A</h2>
-                <p>
-                  Tabs are also controllable if you want to programmatically pass them their values.
-                  This allows for more functionality in Tabs such as not
-                  having any Tab selected or assigning them different values.
-                </p> */}
                 <GroupsListByUserId userId={userId} />
+                <FloatingActionButton mini={true} secondary={true} >
+                  <ContentAdd />
+                </FloatingActionButton>
               </div>
             </Tab>
-
-          <Tab label="Notes" value="b">
+          <Tab label="Notebooks" value="b">
             <div>
               <DocsListByUserId userId={userId} />
+              <FloatingActionButton mini={true} secondary={true} >
+                  <ContentAdd />
+                </FloatingActionButton>
             </div>
           </Tab>
         </Tabs>
+          </div>
         </div>
       </div>
     )

--- a/client/components/SingleUser.js
+++ b/client/components/SingleUser.js
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
-import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
-import {Tabs, Tab} from 'material-ui/Tabs';
+import React, { Component } from 'react';
+import { Card, CardActions, CardHeader, CardMedia, CardTitle, CardText } from 'material-ui/Card';
+import { Tabs, Tab } from 'material-ui/Tabs';
 import FlatButton from 'material-ui/FlatButton';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
 import ContentAdd from 'material-ui/svg-icons/content/add';
@@ -22,7 +22,7 @@ class SingleUser extends Component {
     const { userId } = this.props.match.params;
     this.unsubscribe = db.collection('users').doc(userId)
       .onSnapshot((doc) => {
-        this.setState({userInfo: doc.data()})
+        this.setState({ userInfo: doc.data() });
       });
   }
 
@@ -35,30 +35,28 @@ class SingleUser extends Component {
     this.setState({ userInfo });
   }
 
-  handleChange = (value) => {
-    this.setState({
-      value: value,
-    })
+  handleChange(value) {
+    this.setState({ value });
   }
 
   render() {
     const { userId } = this.state;
     const { userInfo } = this.state;
-    return(
+    return (
       <div>
         <div className="userPage">
           <div className="userPic">
             <CardMedia
-            className="userPic"
+              className="userPic"
               overlay={<CardTitle title="Overlay title" subtitle="Overlay subtitle" />}
             >
-              <img
-              src="https://i0.wp.com/www.thisblogrules.com/wp-content/uploads/2010/02/batman-for-facebook.jpg?resize=250%2C280" alt="" />
+              <img src="https://i0.wp.com/www.thisblogrules.com/wp-content/uploads/2010/02/batman-for-facebook.jpg?resize=250%2C280" alt="" />
             </CardMedia>
 
             <CardTitle
-            title={ `Name: ${userInfo.displayName}` }
-            subtitle="Card subtitle" />
+              title={`Name: ${userInfo.displayName}`}
+              subtitle="Card subtitle"
+            />
             <CardText>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               Donec mattis pretium massa. Aliquam erat volutpat. Nulla facilisi.
@@ -71,31 +69,31 @@ class SingleUser extends Component {
             </CardActions>
           </div>
           <div className="userInfo">
-          <Tabs
-            value={this.state.value}
-            onChange={this.handleChange}
-          >
-            <Tab label="Groups" value="a">
-              <div>
-                <GroupsListByUserId userId={userId} />
-                <FloatingActionButton mini={true} secondary={true} >
-                  <ContentAdd />
-                </FloatingActionButton>
-              </div>
-            </Tab>
-          <Tab label="Notebooks" value="b">
-            <div>
-              <DocsListByUserId userId={userId} />
-              <FloatingActionButton mini={true} secondary={true} >
-                  <ContentAdd />
-                </FloatingActionButton>
-            </div>
-          </Tab>
-        </Tabs>
+            <Tabs
+              value={this.state.value}
+              onChange={this.handleChange}
+            >
+              <Tab label="Groups" value="a">
+                <div>
+                  <GroupsListByUserId userId={userId} />
+                  <FloatingActionButton mini secondary>
+                    <ContentAdd />
+                  </FloatingActionButton>
+                </div>
+              </Tab>
+              <Tab label="Notebooks" value="b">
+                <div>
+                  <DocsListByUserId userId={userId} />
+                  <FloatingActionButton mini secondary>
+                    <ContentAdd />
+                  </FloatingActionButton>
+                </div>
+              </Tab>
+            </Tabs>
           </div>
         </div>
       </div>
-    )
+    );
   }
 }
 

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -82,7 +82,7 @@ export default class Navbar extends Component {
               <Link to="/testSnippet">Notebooks</Link>
               <Link to="/groups/new">CreateGroup</Link>
               <Link to="/groups/Group 2">Show SingleGroup (DEMO)</Link>
-              <Link to="/singleUser">Show SingleUser (DEMO)</Link>
+              {/* <Link to="/singleUser">Show SingleUser (DEMO)</Link> */}
               <h3>Welcome, {this.state.displayName}</h3>
               <Link onClick={this.logout} to="/login">Logout</Link>
             </div>

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -1,12 +1,11 @@
+/* eslint-disable class-methods-use-this */
+
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { logout } from '../store';
 import history from '../history';
 import { fetchUserFunction, addUserFunction } from '../crud/user';
-const { db } = require('../../firebase/initFirebase');
 
-const { auth } = require('../../firebase/initFirebase');
+const { db, auth } = require('../../firebase/initFirebase');
 
 const firebase = require('firebase/app');
 require('firebase/firestore');
@@ -32,19 +31,19 @@ export default class Navbar extends Component {
 
         const { uid } = user;
         db.collection('users').doc(uid).get()
-        .then(userExists => {
-          if (!userExists.data()) {
-            const { email, displayName } = user;
-            const userInfo = {
-              displayName,
-              email,
-              id: uid,
-              documents: {},
-              groups: {},
-            };
-            addUserFunction(uid, userInfo);
-          }
-        })
+          .then((userExists) => {
+            if (!userExists.data()) {
+              const { email, displayName } = user;
+              const userInfo = {
+                displayName,
+                email,
+                id: uid,
+                documents: {},
+                groups: {},
+              };
+              addUserFunction(uid, userInfo);
+            }
+          });
         history.push(`/users/${uid}`);
       } else {
         // no user, set state of isLoggedIn to false


### PR DESCRIPTION
after login with Local or Google account,

(if there is no existing user for the account in the 'user' firebase, create new 'user')

the user is redirected to user's page where the user can see his/her groups and notebooks.

also added '+' buttons to add groups and notebooks in singleUser's page, but the buttons do not have any functionality yet.

You can try with your account (but will not have any group and notebook lists)
or 
you can try with (id: jang@ko.com, PW: 123456) which has some groups and notebooks in the list.


Still need to implement "+" button functionality and redirect to corresponding page when clicked a notebook or a group.