### PR TITLE
minor odds and ends for notebook footer and notebook api

### DIFF
--- a/client/components/NotebookFooter.js
+++ b/client/components/NotebookFooter.js
@@ -10,17 +10,13 @@ import { notebookGroups, addSnippet } from '../crud/notebook';
 import { auth } from '../../firebase/initFirebase';
 import { PlayPauseDelete } from '../components';
 
-const style = {
-  marginRight: 20,
-};
-
 // props: this.props.notebookId
 const Footer = ({ notebookId, users, groups }) => (
-  <Paper zDepth={1} className="single-notebook-footer">
-    <BottomNavigation>
+  <Paper zDepth={1}>
+    <BottomNavigation className="single-notebook-footer">
 
       <div className="footer-left">
-        <FloatingActionButton style={style}>
+        <FloatingActionButton className="footer-add-btn">
           <ContentAdd
             onClick={(evt) => {
               evt.preventDefault();
@@ -33,7 +29,6 @@ const Footer = ({ notebookId, users, groups }) => (
       </div>
 
       <PlayPauseDelete
-        className="footer-right"
         scope="notebook"
         notebookId={notebookId}
       />{/* note "notebook" vs "snippet" scope */}

--- a/client/components/PlayPauseDeleteBtns.js
+++ b/client/components/PlayPauseDeleteBtns.js
@@ -35,8 +35,8 @@ This helper component declares an interface to start ("play") executing code, st
 
 
 const PlayPauseDeleteBtns = ({ scope, notebookId, snippetId }) => (
-  <React.Fragment>
-    <FloatingActionButton>
+  <div className="footer-right">
+    <FloatingActionButton className="footer-play-btn">
       <PlayArrow
         onClick={(evt) => {
           evt.preventDefault();
@@ -46,7 +46,7 @@ const PlayPauseDeleteBtns = ({ scope, notebookId, snippetId }) => (
       />
     </FloatingActionButton>
 
-    <FloatingActionButton>
+    <FloatingActionButton className="footer-pause-btn">
       <Pause
         onClick={(evt) => {
           evt.preventDefault();
@@ -56,7 +56,7 @@ const PlayPauseDeleteBtns = ({ scope, notebookId, snippetId }) => (
       />
     </FloatingActionButton>
 
-    <FloatingActionButton>
+    <FloatingActionButton className="footer-delete-btn">
       <Delete
         onClick={(evt) => {
           evt.preventDefault();
@@ -69,7 +69,7 @@ const PlayPauseDeleteBtns = ({ scope, notebookId, snippetId }) => (
         }}
       />
     </FloatingActionButton>
-  </React.Fragment>
+  </div>
 );
 
 export default PlayPauseDeleteBtns;

--- a/public/style.css
+++ b/public/style.css
@@ -25,7 +25,36 @@ form div {
   position: fixed;
   bottom: 0;
   z-index: 3;
+  width: 100%;
+  display: flex;
+  margin: 8px;
+  padding: 10px 0px 10px 0px;
 }
+
+.footer-right {
+  margin-right: 10px;
+}
+
+.footer-add-btn {
+  margin-left: 10px;
+}
+
+.footer-play-btn, .footer-pause-btn, .footer-delete-btn {
+  margin-right: 10px;
+}
+
+.footer-play-btn > button {
+  width: 25px;
+  height: 25px;
+}
+
+/* ---- play/pause/delete ---- */
+.snippet-play-pause-delete-btns {
+  display: flex;
+  justify-content: flex-end;
+  height: 30px;
+}
+
 
 /* AUTH FORM */
 


### PR DESCRIPTION
tying up some minor odds and ends, like putting class names on divs and components and amending the API method for running all snippets in a notebook so that they run in sequence (with a delay we can specify) or as however many the server can currently handle - in fact, we might consider implementing snippet-running more generally as a queue for the server, where the server would add whatever is currently set to running to the queue, and be constantly looking at that queue for what to run first.

### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] written relevant docs (or none needed)
- [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*
