### PR TITLE
Refactored createEntity

### DIFF
--- a/client/components/CreateNotebook.js
+++ b/client/components/CreateNotebook.js
@@ -16,8 +16,9 @@ export default class CreateNotebook extends Component {
     const createNotebookPromise =
       currentUser ? createNotebook({ currentUser }) : createNotebook({ null: true });
 
+    console.log('creating promise');
     createNotebookPromise
-      .then(docRef => this.setState({ notebookId: docRef.id }));
+      .then((docRef) => { console.log('notebook id: ', docRef.id); this.setState({ notebookId: docRef.id }); });
   }
 
   render() {

--- a/client/components/CreateNotebook.js
+++ b/client/components/CreateNotebook.js
@@ -16,9 +16,8 @@ export default class CreateNotebook extends Component {
     const createNotebookPromise =
       currentUser ? createNotebook({ currentUser }) : createNotebook({ null: true });
 
-    console.log('creating promise');
     createNotebookPromise
-      .then((docRef) => { console.log('notebook id: ', docRef.id); this.setState({ notebookId: docRef.id }); });
+      .then(docRef => this.setState({ notebookId: docRef.id }));
   }
 
   render() {


### PR DESCRIPTION
So I refactored createEntity. But two things come to mind.

1) In order to create the subcollection when the object is empty I just do `add({ exists: false })` but I think that is causing problems with snippets because it doesn't check that. From what I understand, collections are created when you add a document so I don't think there's any other way to do this?
2) Currently I'm doing `Promise.all()` but it may be better to do a batch? Based on the syntax, it seems like I would still be doing `Promise.all()` but just with less promises.