### PR TITLE
Debugging 'delete snippet' front-end interaction

### DIFF
--- a/client/components/SingleNotebook.js
+++ b/client/components/SingleNotebook.js
@@ -117,6 +117,7 @@ export default class SingleNotebook extends Component {
       snippetState[idx] = snippetId;
       return snippetState;
     }, {});
+    console.log('NEW SNIPPETS: ', snippets);
 
     this.setState({ snippets });
   }

--- a/client/components/Snippet.js
+++ b/client/components/Snippet.js
@@ -20,13 +20,13 @@ import { snippetListener, snippetOutputListener, updateSnippetText, snippetById 
 const snippetStyle = {
   margin: '0px 100px 0px 100px',
 };
-/* ----- END STYLES ----- */
+
 
 class Snippet extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      text: 'console.log(\'Hello World!\');',
+      text: '',
       output: '', // Docker client output, via firestore "snippetOutputs" collection
       snippetVisible: true,
       running: false,

--- a/client/crud/notebook.js
+++ b/client/crud/notebook.js
@@ -127,14 +127,21 @@ const removeAllClients = notebookId =>
   db.collection('notebooks')
     .doc(notebookId)
     .set({ clients: {} }, { merge: true });
-const removeDocAuthor = (docId, userId) =>
-  updateEntityField('notebooks', docId, 'users', userId, true, false);
-const removeDocGroup = (docId, groupId) =>
-  updateEntityField('notebooks', docId, 'groups', groupId, true, false);
-const removeNotebookSnippet = (docId, snippetId) => {
-  removeDocFromSubcollection('notebooks', docId, 'snippets', snippetId);
-};
+const removeDocAuthor = (notebookId, userId) =>
+  updateEntityField('notebooks', notebookId, 'users', userId, true, false);
+const removeDocGroup = (notebookId, groupId) =>
+  updateEntityField('notebooks', notebookId, 'groups', groupId, true, false);
 
+const removeNotebookSnippet = (notebookId, snippetId) => {
+  db.collection('notebooks/' + notebookId + '/snippets')
+    .get()
+    .then((snippets) => {
+      const snippetToDelete = snippets.docs.find((doc) => {
+        return Object.keys(doc.data())[0] === snippetId;
+      });
+      removeDocFromSubcollection('notebooks', notebookId, 'snippets', snippetToDelete.id);
+    });
+};
 
 // The following are helper functions for running all snippets in a notebook. The strategy is to take a slight pause (1ms? 10?) after setting the `running` field to `true` for each snippet in a notebook, to avoid concurrency issues with actually running snippets.
 // Resource on `sleep`: https://stackoverflow.com/questions/951021/what-is-the-javascript-version-of-sleep?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa

--- a/client/crud/notebook.js
+++ b/client/crud/notebook.js
@@ -45,8 +45,10 @@ const notebookClientListener = (notebookId, callback) =>
   db.collection('notebooks/' + notebookId + '/clients').onSnapshot(callback);
 const notebookGroupListener = (notebookId, callback) =>
   db.collection('notebooks/' + notebookId + '/groups').onSnapshot(callback);
-const notebookSnippetListener = (notebookId, callback) =>
+const notebookSnippetListener = (notebookId, callback) => {
+  console.log('GOT TO notebookSnippetListener');
   db.collection('notebooks/' + notebookId + '/snippets').onSnapshot(callback);
+}
 
   // .then(({ docs }) => docs.filter(d => d.data().exists).map(d => d.id));
   // db.collection(collectionName)
@@ -129,8 +131,9 @@ const removeDocAuthor = (docId, userId) =>
   updateEntityField('notebooks', docId, 'users', userId, true, false);
 const removeDocGroup = (docId, groupId) =>
   updateEntityField('notebooks', docId, 'groups', groupId, true, false);
-const removeNotebookSnippet = (docId, snippetId) =>
+const removeNotebookSnippet = (docId, snippetId) => {
   removeDocFromSubcollection('notebooks', docId, 'snippets', snippetId);
+};
 
 
 // The following are helper functions for running all snippets in a notebook. The strategy is to take a slight pause (1ms? 10?) after setting the `running` field to `true` for each snippet in a notebook, to avoid concurrency issues with actually running snippets.

--- a/client/crud/snippet.js
+++ b/client/crud/snippet.js
@@ -293,13 +293,7 @@ const markSnippetAsRunning = id => changeSnippetRunningStatus(id, true);
 const markSnippetAsDormant = id => changeSnippetRunningStatus(id, false);
 
 // delete a snippet
-const deleteSnippet = (snippetId) => {
-  db.collection('snippets')
-    .doc(snippetId)
-    .delete()
-    .then(() => console.log('Snippet successfully deleted!'))
-    .catch(error => console.error('Error removing snippet: ', error));
-};
+const deleteSnippet = snippetId => db.collection('snippets').doc(snippetId).delete();
 
 module.exports = {
   // C


### PR DESCRIPTION
Deleting snippets from notebooks front-end interaction successfully debugged. Notebook now visually represents its contemporary snippets.

The trick was that since snippets are added to a notebook according to their order, deletion requires a subroutine to find the correct *index* of the snippet to delete, and then remove *that index* (and its associated snippet reference) from the notebook.

Additionally, this debugging adventure uncovered buggy behavior in the createNotebook component, which has also been fixed. Note that 'clients' behavior is still buggy (but we aren't utilizing that, so it's not mission-critical).